### PR TITLE
add a backup for the environment variables named `TIMEOUT`, `QUIT`, `…

### DIFF
--- a/wait-for
+++ b/wait-for
@@ -1,5 +1,10 @@
 #!/bin/sh
 
+OLD_TIMEOUT=$TIMEOUT
+OLD_QUIET=$QUIET
+OLD_PORT=$PORT
+OLD_HOST=$HOST
+
 TIMEOUT=15
 QUIET=0
 
@@ -20,14 +25,13 @@ USAGE
 }
 
 wait_for() {
-  command="$*"
   for i in `seq $TIMEOUT` ; do
     nc -z "$HOST" "$PORT" > /dev/null 2>&1
     
     result=$?
     if [ $result -eq 0 ] ; then
-      if [ -n "$command" ] ; then
-        exec $command
+      if [ $# -gt 0 ] ; then
+        TIMEOUT=$OLD_TIMEOUT QUIET=$OLD_QUIET PORT=$OLD_PORT HOST=$OLD_HOST exec "$@"
       fi
       exit 0
     fi


### PR DESCRIPTION
when i was working with a node server I noticed that the app is not working after adding this script and the problem was that the env var named PORT is overridden by the script.
So to fix this and for all I changed the code to make a backup for each of TIMEOUT, QUIET, PORT, HOST.